### PR TITLE
feat(camera): add capture, preview, and gallery save on Android

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.CAMERA" />
+    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="28" />
     <application
         android:label="detection_game"
         android:name="${applicationName}"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,6 +34,8 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
+  image_picker: ^1.1.2
+  gallery_saver: ^2.3.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
# 機能追加: カメラ撮影・プレビュー表示・ギャラリー保存（Android）

このPRでは、Issue #1 の要望に基づき、以下の機能を追加しました。

- MyHomePage（メイン画面）に「撮影」ボタンを追加
- 端末のカメラで写真を撮影（image_picker 使用）
- 撮影した画像をアプリ内でプレビュー表示
- 画像を端末のギャラリーに保存（gallery_saver 使用）
- Android向けの必要な権限を追加（SDKバージョンに応じた設定）

変更点
- 依存関係の追加（pubspec.yaml）
  - image_picker: カメラ撮影に使用
  - gallery_saver: ギャラリー保存に使用
- UI・ロジックの実装（lib/main.dart / MyHomePage）
  - 「撮影」ボタンを追加
  - 撮影処理、保存処理、エラーハンドリング（日本語メッセージ）
  - プレビュー表示（280x280, cover）
- Android権限の追加（android/app/src/main/AndroidManifest.xml）
  - CAMERA
  - READ_MEDIA_IMAGES（Android 13+）
  - 互換用の READ/WRITE_EXTERNAL_STORAGE（maxSdkVersion 付与）

動作確認の目安
1) flutter pub get
2) 実機/エミュレータでビルド・起動
3) 「撮影」ボタン → カメラ起動 → 撮影
4) アプリ内でプレビュー表示されることを確認
5) 端末のギャラリーに保存されていることを確認

補足
- この環境（VM）には Flutter SDK が未インストールのため、こちらではローカルビルドは未実施です。お手元での確認をお願いします（必要であれば当方で Flutter 導入して検証可能です）。
- エラー時は日本語メッセージを表示します（例：「保存に失敗しました」など）。

関連
- リクエスト: koji さん（@KJMAN678）
- Devin 実行ログ: https://app.devin.ai/sessions/6a60440465ef46eb90bdcab3f3656a8a
