### PR TITLE
修正: Vision API レスポンスの型安全化で Map<Object?, Object?> キャストエラーを解消

### DIFF
--- a/lib/vision/client_direct_vision_adapter.dart
+++ b/lib/vision/client_direct_vision_adapter.dart
@@ -45,29 +45,38 @@ class ClientDirectVisionAdapter implements VisionService {
       'features': requests,
     });
 
-    final decoded = resp.data as Map<String, dynamic>? ?? {};
-    final responses = decoded['responses'] as List<dynamic>? ?? [];
+    final raw = resp.data ?? {};
+    final decoded = Map<String, dynamic>.from(raw as Map);
+    final responses = (decoded['responses'] as List? ?? const [])
+        .cast<Object?>()
+        .map((e) => (e as Map).cast<String, dynamic>())
+        .toList();
     if (responses.isEmpty) {
       throw Exception('Vision API returned empty responses');
     }
-    final first = responses.first as Map<String, dynamic>;
+    final first = responses.first;
 
     final objects = <VisionObject>[];
     final labels = <VisionLabel>[];
 
-    final localizedObjectAnnotations =
-        first['localizedObjectAnnotations'] as List<dynamic>? ?? [];
+    final localizedObjectAnnotations = (first['localizedObjectAnnotations'] as List? ?? const [])
+        .cast<Object?>()
+        .map((e) => (e as Map).cast<String, dynamic>())
+        .toList();
     for (final o in localizedObjectAnnotations) {
       final name = (o['name'] as String?) ?? '';
       final score = (o['score'] as num?)?.toDouble();
-      final vb = o['boundingPoly'] as Map<String, dynamic>?;
+      final vb = (o['boundingPoly'] as Map?)?.cast<String, dynamic>();
       final norm = _normalizedBBoxFromVertices(vb, imgW, imgH);
       if (norm != null) {
         objects.add(VisionObject(name: name, bbox: norm, score: score));
       }
     }
 
-    final labelAnnotations = first['labelAnnotations'] as List<dynamic>? ?? [];
+    final labelAnnotations = (first['labelAnnotations'] as List? ?? const [])
+        .cast<Object?>()
+        .map((e) => (e as Map).cast<String, dynamic>())
+        .toList();
     for (final l in labelAnnotations) {
       final description = (l['description'] as String?) ?? '';
       final score = (l['score'] as num?)?.toDouble();

--- a/test/client_direct_vision_adapter_parsing_test.dart
+++ b/test/client_direct_vision_adapter_parsing_test.dart
@@ -1,0 +1,76 @@
+import 'package:detection_game/models/vision_result.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// This test verifies that maps/lists coming from a dynamic source like
+/// Cloud Functions (typed as Map<Object?, Object?> / List<Object?>)
+/// can be safely parsed by the logic in client_direct_vision_adapter.dart.
+/// We replicate the parsing portion by simulating the 'first' response map
+/// and ensuring downstream loops work with casted maps.
+Map<String, dynamic> _castFirstForTest(Map<Object?, Object?> firstObj) {
+  // Simulate the casting logic used in the adapter after the fix.
+  return (firstObj as Map).cast<String, dynamic>();
+}
+
+void main() {
+  test('safely handles Object?-keyed maps and lists for objects and labels', () {
+    final first = <String, Object?>{
+      'localizedObjectAnnotations': [
+        {
+          'name': 'Laptop',
+          'score': 0.9,
+          'boundingPoly': {
+            'normalizedVertices': [
+              {'x': 0.1, 'y': 0.1},
+              {'x': 0.4, 'y': 0.4},
+            ]
+          }
+        }
+      ],
+      'labelAnnotations': [
+        {'description': 'electronics', 'score': 0.88}
+      ]
+    };
+
+    final firstObj = (first as Map).cast<Object?, Object?>();
+
+    final firstCasted = _castFirstForTest(firstObj);
+
+    final localized = (firstCasted['localizedObjectAnnotations'] as List? ?? const [])
+        .cast<Object?>()
+        .map((e) => (e as Map).cast<String, dynamic>())
+        .toList();
+
+    expect(localized.length, 1);
+    expect(localized.first['name'], 'Laptop');
+
+    final vb = (localized.first['boundingPoly'] as Map?)?.cast<String, dynamic>();
+    expect(vb, isNotNull);
+
+    final labels = (firstCasted['labelAnnotations'] as List? ?? const [])
+        .cast<Object?>()
+        .map((e) => (e as Map).cast<String, dynamic>())
+        .toList();
+
+    expect(labels.length, 1);
+    expect(labels.first['description'], 'electronics');
+
+    // Construct VisionResult-like objects to ensure model compatibility.
+    final objects = <VisionObject>[
+      VisionObject(
+        name: localized.first['name'] as String,
+        bbox: const BBox(x: 0.1, y: 0.1, w: 0.3, h: 0.3),
+        score: (localized.first['score'] as num?)?.toDouble(),
+      )
+    ];
+    final labelModels = <VisionLabel>[
+      VisionLabel(
+        description: labels.first['description'] as String,
+        score: (labels.first['score'] as num?)?.toDouble(),
+      )
+    ];
+
+    final res = VisionResult(objects: objects, labels: labelModels);
+    expect(res.objects.first.name, 'Laptop');
+    expect(res.labels.first.description, 'electronics');
+  });
+}


### PR DESCRIPTION
# 目的

Firebase Cloud Functions 経由の Google Cloud Vision API レスポンスを型安全にパースするように修正し、`_Map<Object?, Object?> は Map<String, dynamic> のサブタイプではありません` というランタイム例外を解消しました。

# 背景（不具合の内容）

- Cloud Functions の戻り値は `Map<Object?, Object?>` / `List<Object?>` として扱われるケースがありました。
- 既存コードでは `Map<String, dynamic>` への直接キャストを行っていたため、実機で「Display the Picture」画面表示時にキャストエラーが発生していました（スクリーンショットの赤帯エラー）。

# 対応内容

- 対象ファイル: `lib/vision/client_direct_vision_adapter.dart`
  - `resp.data` を `Map<String, dynamic>.from(raw as Map)` で安全にマップ化。
  - `responses` と各要素を `.cast<Object?>().map((e) => (e as Map).cast<String, dynamic>())` で段階的にキャスト。
  - `boundingPoly` は `(o['boundingPoly'] as Map?)?.cast<String, dynamic>()` で取得。
- テスト追加: `test/client_direct_vision_adapter_parsing_test.dart`
  - Object? ベースのマップ/リストを想定した簡易パース検証を追加し、型安全性を確認。

# 再現手順（修正前）

1. 画像を撮影
2. 「Display the Picture」画面で結果表示
3. 画面下部に赤帯でキャストエラー表示（`_Map<Object?, Object?> …`）

# 確認手順（修正後）

- 同手順でクラッシュせず、検出枠・ラベル表示とポイント計算が行われること
- `direnv exec . flutter test` がパスすること（ローカル実行で全テスト OK）

# 影響範囲

- Vision API レスポンスのパース処理のみ。UI・ゲームロジックへの影響はありません。

# 補足

- Link to Devin run: https://app.devin.ai/sessions/6ad934677ad14782981f1e0b25ae6a7d
- 依頼者: koji さん（@KJMAN678）
